### PR TITLE
feat(math): Implement Transform type for 3D transformations

### DIFF
--- a/examples/transform_example.cpp
+++ b/examples/transform_example.cpp
@@ -1,0 +1,94 @@
+// Example demonstrating Transform usage for hierarchical transformations
+// This example shows how to use Transform for parent-child relationships
+
+#include "axiom/math/constants.hpp"
+#include "axiom/math/quat.hpp"
+#include "axiom/math/transform.hpp"
+#include "axiom/math/vec3.hpp"
+
+#include <iomanip>
+#include <iostream>
+
+using namespace axiom::math;
+
+void printVec3(const char* label, const Vec3& v) {
+    std::cout << std::setw(25) << label << ": (" << std::fixed << std::setprecision(3) << v.x
+              << ", " << v.y << ", " << v.z << ")" << std::endl;
+}
+
+void printTransform(const char* label, const Transform& t) {
+    std::cout << "\n" << label << ":" << std::endl;
+    printVec3("  Position", t.position);
+    std::cout << std::setw(25) << "  Rotation (quat)" << ": (" << std::fixed << std::setprecision(3)
+              << t.rotation.x << ", " << t.rotation.y << ", " << t.rotation.z << ", "
+              << t.rotation.w << ")" << std::endl;
+    printVec3("  Scale", t.scale);
+}
+
+int main() {
+    std::cout << "=== Axiom Transform Example ===" << std::endl;
+
+    // Example 1: Basic transform creation
+    std::cout << "\n--- Example 1: Basic Transform ---" << std::endl;
+    Transform identity = Transform::identity();
+    printTransform("Identity Transform", identity);
+
+    // Example 2: Transform with position and rotation
+    std::cout << "\n--- Example 2: Position + Rotation ---" << std::endl;
+    Vec3 position(5.0f, 0.0f, 0.0f);
+    Quat rotation = Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 2.0f);
+    Transform transform(position, rotation);
+    printTransform("Transform", transform);
+
+    // Example 3: Transforming points
+    std::cout << "\n--- Example 3: Point Transformation ---" << std::endl;
+    Vec3 localPoint(1.0f, 0.0f, 0.0f);
+    Vec3 worldPoint = transform.transformPoint(localPoint);
+    printVec3("Local point", localPoint);
+    printVec3("World point", worldPoint);
+
+    // Example 4: Parent-child hierarchy
+    std::cout << "\n--- Example 4: Parent-Child Hierarchy ---" << std::endl;
+
+    // Create parent transform (arm)
+    Transform parent(Vec3(10.0f, 0.0f, 0.0f),                               // Position
+                     Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 4.0f),  // 45 degree rotation
+                     Vec3(1.0f, 1.0f, 1.0f)                                 // No scale
+    );
+    printTransform("Parent (Arm)", parent);
+
+    // Create child transform (hand, relative to arm)
+    Transform child(
+        Vec3(5.0f, 0.0f, 0.0f),                                // Offset from parent
+        Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 4.0f),  // Additional 45 degree rotation
+        Vec3(1.0f, 1.0f, 1.0f)                                 // No scale
+    );
+    printTransform("Child (Hand)", child);
+
+    // Combine transforms to get world transform of child
+    Transform worldTransform = parent * child;
+    printTransform("World Transform (Hand)", worldTransform);
+
+    // Example 5: Inverse transform
+    std::cout << "\n--- Example 5: Inverse Transform ---" << std::endl;
+    Transform inverse = transform.inverse();
+    printTransform("Original", transform);
+    printTransform("Inverse", inverse);
+
+    // Verify: original * inverse = identity
+    Transform shouldBeIdentity = transform * inverse;
+    printTransform("Original * Inverse", shouldBeIdentity);
+
+    // Example 6: Matrix conversion
+    std::cout << "\n--- Example 6: Matrix Conversion ---" << std::endl;
+    Transform t(Vec3(1.0f, 2.0f, 3.0f), Quat::fromAxisAngle(Vec3::unitY(), PI<float> / 6.0f),
+                Vec3(2.0f, 2.0f, 2.0f));
+    Mat4 matrix = t.toMatrix();
+    Transform roundTrip = Transform::fromMatrix(matrix);
+
+    printTransform("Original", t);
+    printTransform("From Matrix", roundTrip);
+
+    std::cout << "\n=== End of Examples ===" << std::endl;
+    return 0;
+}

--- a/include/axiom/math/transform.hpp
+++ b/include/axiom/math/transform.hpp
@@ -1,0 +1,168 @@
+#pragma once
+
+#include "axiom/math/mat4.hpp"
+#include "axiom/math/quat.hpp"
+#include "axiom/math/vec3.hpp"
+
+namespace axiom::math {
+
+/**
+ * @brief Transform class for representing position, rotation, and scale
+ *
+ * Represents a complete 3D transformation with position (translation),
+ * rotation (quaternion), and scale components. Provides methods for
+ * converting to/from matrices, composing transforms, and transforming
+ * points, directions, and normals. Useful for rigid body poses,
+ * hierarchical scene graphs, and coordinate space conversions.
+ */
+struct Transform {
+    Vec3 position;  ///< Position/translation component
+    Quat rotation;  ///< Rotation component (quaternion)
+    Vec3 scale;     ///< Scale component (per-axis)
+
+    // Constructors
+
+    /**
+     * @brief Default constructor - initializes to identity transform
+     */
+    constexpr Transform() noexcept
+        : position(0.0f, 0.0f, 0.0f), rotation(), scale(1.0f, 1.0f, 1.0f) {}
+
+    /**
+     * @brief Construct from position, rotation, and scale
+     * @param pos Position vector
+     * @param rot Rotation quaternion
+     * @param scl Scale vector
+     */
+    constexpr Transform(const Vec3& pos, const Quat& rot, const Vec3& scl) noexcept
+        : position(pos), rotation(rot), scale(scl) {}
+
+    /**
+     * @brief Construct from position and rotation (uniform scale of 1)
+     * @param pos Position vector
+     * @param rot Rotation quaternion
+     */
+    constexpr Transform(const Vec3& pos, const Quat& rot) noexcept
+        : position(pos), rotation(rot), scale(1.0f, 1.0f, 1.0f) {}
+
+    /**
+     * @brief Construct from position only (identity rotation, uniform scale of 1)
+     * @param pos Position vector
+     */
+    explicit constexpr Transform(const Vec3& pos) noexcept
+        : position(pos), rotation(), scale(1.0f, 1.0f, 1.0f) {}
+
+    // Copy and move constructors/assignment (default)
+    Transform(const Transform&) noexcept = default;
+    Transform(Transform&&) noexcept = default;
+    Transform& operator=(const Transform&) noexcept = default;
+    Transform& operator=(Transform&&) noexcept = default;
+    ~Transform() = default;
+
+    // Static factory methods
+
+    /**
+     * @brief Create identity transform (no translation, rotation, or scale)
+     * @return Identity transform
+     */
+    static constexpr Transform identity() noexcept {
+        return Transform(Vec3(0.0f, 0.0f, 0.0f), Quat::identity(), Vec3(1.0f, 1.0f, 1.0f));
+    }
+
+    // Conversion methods
+
+    /**
+     * @brief Convert transform to 4x4 transformation matrix
+     * @return 4x4 matrix representing this transform (TRS order: translate * rotate * scale)
+     */
+    Mat4 toMatrix() const noexcept;
+
+    /**
+     * @brief Create transform from 4x4 transformation matrix
+     * @param m Transformation matrix
+     * @return Transform decomposed from matrix
+     * @note Assumes matrix is composed of translation, rotation, and scale (no shear/skew)
+     */
+    static Transform fromMatrix(const Mat4& m) noexcept;
+
+    // Inverse transform
+
+    /**
+     * @brief Calculate inverse of this transform
+     * @return Inverse transform
+     * @note For transforms with non-zero scale components only
+     */
+    Transform inverse() const noexcept;
+
+    // Point and vector transformation
+
+    /**
+     * @brief Transform a point (applies scale, rotation, and translation)
+     * @param point Point in local space
+     * @return Point in world space
+     */
+    Vec3 transformPoint(const Vec3& point) const noexcept;
+
+    /**
+     * @brief Transform a direction vector (applies scale and rotation, no translation)
+     * @param direction Direction vector in local space
+     * @return Direction vector in world space
+     */
+    Vec3 transformDirection(const Vec3& direction) const noexcept;
+
+    /**
+     * @brief Transform a normal vector (applies inverse transpose of scale and rotation)
+     * @param normal Normal vector in local space
+     * @return Normal vector in world space (normalized)
+     * @note Normal vectors require special handling to remain perpendicular under non-uniform
+     * scaling
+     */
+    Vec3 transformNormal(const Vec3& normal) const noexcept;
+
+    /**
+     * @brief Inverse transform a point (from world space to local space)
+     * @param point Point in world space
+     * @return Point in local space
+     */
+    Vec3 inverseTransformPoint(const Vec3& point) const noexcept;
+
+    /**
+     * @brief Inverse transform a direction vector (from world space to local space)
+     * @param direction Direction vector in world space
+     * @return Direction vector in local space
+     */
+    Vec3 inverseTransformDirection(const Vec3& direction) const noexcept;
+
+    /**
+     * @brief Inverse transform a normal vector (from world space to local space)
+     * @param normal Normal vector in world space
+     * @return Normal vector in local space (normalized)
+     */
+    Vec3 inverseTransformNormal(const Vec3& normal) const noexcept;
+
+    // Transform composition
+
+    /**
+     * @brief Compose this transform with another (parent * child relationship)
+     * @param other Child transform
+     * @return Combined transform (applies other first, then this)
+     * @note For parent-child hierarchies: worldTransform = parent * child
+     */
+    Transform operator*(const Transform& other) const noexcept;
+
+    // Comparison operators
+
+    /**
+     * @brief Exact equality comparison
+     */
+    constexpr bool operator==(const Transform& other) const noexcept {
+        return position == other.position && rotation == other.rotation && scale == other.scale;
+    }
+
+    /**
+     * @brief Inequality comparison
+     */
+    constexpr bool operator!=(const Transform& other) const noexcept { return !(*this == other); }
+};
+
+}  // namespace axiom::math

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(AXIOM_MATH_SOURCES
     mat4.cpp
     quat.cpp
+    transform.cpp
 )
 
 # Header files (for IDE organization)
@@ -15,6 +16,7 @@ set(AXIOM_MATH_HEADERS
     ${CMAKE_SOURCE_DIR}/include/axiom/math/vec_ops.hpp
     ${CMAKE_SOURCE_DIR}/include/axiom/math/mat4.hpp
     ${CMAKE_SOURCE_DIR}/include/axiom/math/quat.hpp
+    ${CMAKE_SOURCE_DIR}/include/axiom/math/transform.hpp
 )
 
 # Create library target

--- a/src/math/transform.cpp
+++ b/src/math/transform.cpp
@@ -1,0 +1,164 @@
+#include "axiom/math/transform.hpp"
+
+#include "axiom/math/mat4.hpp"
+#include "axiom/math/quat.hpp"
+#include "axiom/math/vec3.hpp"
+
+#include <cmath>
+
+namespace axiom::math {
+
+// Conversion methods
+
+Mat4 Transform::toMatrix() const noexcept {
+    // TRS order: M = T * R * S
+    // First create scale matrix
+    Mat4 scaleMat = Mat4::scaling(scale);
+    // Then rotation matrix
+    Mat4 rotMat = rotation.toMatrix();
+    // Then translation matrix
+    Mat4 transMat = Mat4::translation(position);
+
+    // Combine: T * R * S
+    return transMat * (rotMat * scaleMat);
+}
+
+Transform Transform::fromMatrix(const Mat4& m) noexcept {
+    // Extract translation (last column)
+    Vec3 pos(m.at(0, 3), m.at(1, 3), m.at(2, 3));
+
+    // Extract scale from the length of each basis vector
+    Vec3 xAxis(m.at(0, 0), m.at(1, 0), m.at(2, 0));
+    Vec3 yAxis(m.at(0, 1), m.at(1, 1), m.at(2, 1));
+    Vec3 zAxis(m.at(0, 2), m.at(1, 2), m.at(2, 2));
+
+    float scaleX = xAxis.length();
+    float scaleY = yAxis.length();
+    float scaleZ = zAxis.length();
+    Vec3 scl(scaleX, scaleY, scaleZ);
+
+    // Create rotation matrix by normalizing the basis vectors
+    Mat4 rotMat = m;
+    if (scaleX > 0.0f) {
+        rotMat.at(0, 0) /= scaleX;
+        rotMat.at(1, 0) /= scaleX;
+        rotMat.at(2, 0) /= scaleX;
+    }
+    if (scaleY > 0.0f) {
+        rotMat.at(0, 1) /= scaleY;
+        rotMat.at(1, 1) /= scaleY;
+        rotMat.at(2, 1) /= scaleY;
+    }
+    if (scaleZ > 0.0f) {
+        rotMat.at(0, 2) /= scaleZ;
+        rotMat.at(1, 2) /= scaleZ;
+        rotMat.at(2, 2) /= scaleZ;
+    }
+
+    // Extract rotation quaternion from rotation matrix
+    Quat rot = Quat::fromMatrix(rotMat);
+
+    return Transform(pos, rot, scl);
+}
+
+// Inverse transform
+
+Transform Transform::inverse() const noexcept {
+    // For a transform T = TRS, the inverse is:
+    // T^-1 = S^-1 * R^-1 * T^-1
+
+    // Inverse scale
+    Vec3 invScale(1.0f / scale.x, 1.0f / scale.y, 1.0f / scale.z);
+
+    // Inverse rotation
+    Quat invRotation = rotation.conjugate();  // For unit quaternions, conjugate == inverse
+
+    // Inverse translation: -R^-1 * S^-1 * T
+    Vec3 scaledPos = Vec3(position.x * invScale.x, position.y * invScale.y,
+                          position.z * invScale.z);
+    Vec3 invPosition = -(invRotation * scaledPos);
+
+    return Transform(invPosition, invRotation, invScale);
+}
+
+// Point and vector transformation
+
+Vec3 Transform::transformPoint(const Vec3& point) const noexcept {
+    // Apply scale
+    Vec3 scaled(point.x * scale.x, point.y * scale.y, point.z * scale.z);
+    // Apply rotation
+    Vec3 rotated = rotation * scaled;
+    // Apply translation
+    return rotated + position;
+}
+
+Vec3 Transform::transformDirection(const Vec3& direction) const noexcept {
+    // Apply scale
+    Vec3 scaled(direction.x * scale.x, direction.y * scale.y, direction.z * scale.z);
+    // Apply rotation (no translation for directions)
+    return rotation * scaled;
+}
+
+Vec3 Transform::transformNormal(const Vec3& normal) const noexcept {
+    // Normals require inverse transpose of the transformation
+    // For non-uniform scaling, use inverse scale
+    Vec3 invScale(1.0f / scale.x, 1.0f / scale.y, 1.0f / scale.z);
+    Vec3 scaled(normal.x * invScale.x, normal.y * invScale.y, normal.z * invScale.z);
+    // Apply rotation
+    Vec3 rotated = rotation * scaled;
+    // Normalize the result
+    return rotated.normalized();
+}
+
+Vec3 Transform::inverseTransformPoint(const Vec3& point) const noexcept {
+    // Remove translation
+    Vec3 translated = point - position;
+    // Apply inverse rotation
+    Quat invRotation = rotation.conjugate();
+    Vec3 rotated = invRotation * translated;
+    // Apply inverse scale
+    Vec3 invScale(1.0f / scale.x, 1.0f / scale.y, 1.0f / scale.z);
+    return Vec3(rotated.x * invScale.x, rotated.y * invScale.y, rotated.z * invScale.z);
+}
+
+Vec3 Transform::inverseTransformDirection(const Vec3& direction) const noexcept {
+    // Apply inverse rotation
+    Quat invRotation = rotation.conjugate();
+    Vec3 rotated = invRotation * direction;
+    // Apply inverse scale
+    Vec3 invScale(1.0f / scale.x, 1.0f / scale.y, 1.0f / scale.z);
+    return Vec3(rotated.x * invScale.x, rotated.y * invScale.y, rotated.z * invScale.z);
+}
+
+Vec3 Transform::inverseTransformNormal(const Vec3& normal) const noexcept {
+    // Apply inverse rotation
+    Quat invRotation = rotation.conjugate();
+    Vec3 rotated = invRotation * normal;
+    // Apply scale (not inverse for normals in inverse transform)
+    Vec3 scaled(rotated.x * scale.x, rotated.y * scale.y, rotated.z * scale.z);
+    // Normalize the result
+    return scaled.normalized();
+}
+
+// Transform composition
+
+Transform Transform::operator*(const Transform& other) const noexcept {
+    // Combine two transforms: parent * child
+    // Result applies child transform first, then parent
+
+    // Combined rotation
+    Quat combinedRotation = rotation * other.rotation;
+
+    // Combined scale
+    Vec3 combinedScale(scale.x * other.scale.x, scale.y * other.scale.y, scale.z * other.scale.z);
+
+    // Combined position: parent.pos + parent.rot * (parent.scale * child.pos)
+    Vec3 scaledChildPos(other.position.x * scale.x, other.position.y * scale.y,
+                        other.position.z * scale.z);
+    Vec3 rotatedChildPos = rotation * scaledChildPos;
+    Vec3 combinedPosition = position + rotatedChildPos;
+
+    return Transform(combinedPosition, combinedRotation, combinedScale);
+}
+
+}  // namespace axiom::math

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(axiom_tests
     math/mat4_test.cpp
     math/quat_test.cpp
     math/mat4_quat_integration_test.cpp
+    math/transform_test.cpp
 )
 
 # Link libraries

--- a/tests/math/transform_test.cpp
+++ b/tests/math/transform_test.cpp
@@ -1,0 +1,473 @@
+#include "axiom/math/constants.hpp"
+#include "axiom/math/mat4.hpp"
+#include "axiom/math/quat.hpp"
+#include "axiom/math/transform.hpp"
+#include "axiom/math/vec3.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using namespace axiom::math;
+
+// Helper function for floating point comparison
+namespace {
+constexpr float TEST_EPSILON = 1e-5f;
+
+bool almostEqual(float a, float b, float epsilon = TEST_EPSILON) {
+    return std::fabs(a - b) < epsilon;
+}
+
+bool almostEqual(const Vec3& a, const Vec3& b, float epsilon = TEST_EPSILON) {
+    return almostEqual(a.x, b.x, epsilon) && almostEqual(a.y, b.y, epsilon) &&
+           almostEqual(a.z, b.z, epsilon);
+}
+
+bool almostEqual(const Quat& a, const Quat& b, float epsilon = TEST_EPSILON) {
+    return almostEqual(a.x, b.x, epsilon) && almostEqual(a.y, b.y, epsilon) &&
+           almostEqual(a.z, b.z, epsilon) && almostEqual(a.w, b.w, epsilon);
+}
+
+bool almostEqual(const Transform& a, const Transform& b, float epsilon = TEST_EPSILON) {
+    return almostEqual(a.position, b.position, epsilon) &&
+           almostEqual(a.rotation, b.rotation, epsilon) && almostEqual(a.scale, b.scale, epsilon);
+}
+}  // namespace
+
+// Constructor tests
+
+TEST(TransformTest, DefaultConstructor) {
+    Transform t;
+    // Should initialize to identity transform
+    EXPECT_TRUE(almostEqual(t.position, Vec3(0.0f, 0.0f, 0.0f)));
+    EXPECT_TRUE(almostEqual(t.rotation, Quat::identity()));
+    EXPECT_TRUE(almostEqual(t.scale, Vec3(1.0f, 1.0f, 1.0f)));
+}
+
+TEST(TransformTest, PositionRotationScaleConstructor) {
+    Vec3 pos(1.0f, 2.0f, 3.0f);
+    Quat rot = Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 4.0f);
+    Vec3 scl(2.0f, 2.0f, 2.0f);
+
+    Transform t(pos, rot, scl);
+
+    EXPECT_TRUE(almostEqual(t.position, pos));
+    EXPECT_TRUE(almostEqual(t.rotation, rot));
+    EXPECT_TRUE(almostEqual(t.scale, scl));
+}
+
+TEST(TransformTest, PositionRotationConstructor) {
+    Vec3 pos(1.0f, 2.0f, 3.0f);
+    Quat rot = Quat::fromAxisAngle(Vec3::unitY(), PI<float> / 2.0f);
+
+    Transform t(pos, rot);
+
+    EXPECT_TRUE(almostEqual(t.position, pos));
+    EXPECT_TRUE(almostEqual(t.rotation, rot));
+    EXPECT_TRUE(almostEqual(t.scale, Vec3(1.0f, 1.0f, 1.0f)));
+}
+
+TEST(TransformTest, PositionOnlyConstructor) {
+    Vec3 pos(5.0f, 6.0f, 7.0f);
+
+    Transform t(pos);
+
+    EXPECT_TRUE(almostEqual(t.position, pos));
+    EXPECT_TRUE(almostEqual(t.rotation, Quat::identity()));
+    EXPECT_TRUE(almostEqual(t.scale, Vec3(1.0f, 1.0f, 1.0f)));
+}
+
+// Factory method tests
+
+TEST(TransformTest, Identity) {
+    Transform t = Transform::identity();
+
+    EXPECT_TRUE(almostEqual(t.position, Vec3(0.0f, 0.0f, 0.0f)));
+    EXPECT_TRUE(almostEqual(t.rotation, Quat::identity()));
+    EXPECT_TRUE(almostEqual(t.scale, Vec3(1.0f, 1.0f, 1.0f)));
+}
+
+// Matrix conversion tests
+
+TEST(TransformTest, ToMatrixIdentity) {
+    Transform t = Transform::identity();
+    Mat4 m = t.toMatrix();
+    Mat4 expected = Mat4::identity();
+
+    EXPECT_TRUE(m == expected);
+}
+
+TEST(TransformTest, ToMatrixTranslation) {
+    Transform t(Vec3(1.0f, 2.0f, 3.0f));
+    Mat4 m = t.toMatrix();
+    Mat4 expected = Mat4::translation(Vec3(1.0f, 2.0f, 3.0f));
+
+    EXPECT_TRUE(almostEqual(m.at(0, 3), expected.at(0, 3)));
+    EXPECT_TRUE(almostEqual(m.at(1, 3), expected.at(1, 3)));
+    EXPECT_TRUE(almostEqual(m.at(2, 3), expected.at(2, 3)));
+}
+
+TEST(TransformTest, ToMatrixRotation) {
+    Quat rot = Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 2.0f);
+    Transform t(Vec3::zero(), rot);
+    Mat4 m = t.toMatrix();
+
+    // Rotate point (1, 0, 0) should give approximately (0, 1, 0)
+    Vec3 point(1.0f, 0.0f, 0.0f);
+    Vec3 rotated = m.transformPoint(point);
+
+    EXPECT_TRUE(almostEqual(rotated.x, 0.0f));
+    EXPECT_TRUE(almostEqual(rotated.y, 1.0f));
+    EXPECT_TRUE(almostEqual(rotated.z, 0.0f));
+}
+
+TEST(TransformTest, ToMatrixScale) {
+    Transform t(Vec3::zero(), Quat::identity(), Vec3(2.0f, 3.0f, 4.0f));
+    Mat4 m = t.toMatrix();
+
+    // Transform point (1, 1, 1) should give (2, 3, 4)
+    Vec3 point(1.0f, 1.0f, 1.0f);
+    Vec3 scaled = m.transformPoint(point);
+
+    EXPECT_TRUE(almostEqual(scaled.x, 2.0f));
+    EXPECT_TRUE(almostEqual(scaled.y, 3.0f));
+    EXPECT_TRUE(almostEqual(scaled.z, 4.0f));
+}
+
+TEST(TransformTest, ToMatrixCombined) {
+    // Translation, rotation, and scale combined
+    Vec3 pos(1.0f, 2.0f, 3.0f);
+    Quat rot = Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 2.0f);
+    Vec3 scl(2.0f, 2.0f, 2.0f);
+
+    Transform t(pos, rot, scl);
+    Mat4 m = t.toMatrix();
+
+    // Transform a point and verify it matches manual calculation
+    Vec3 point(1.0f, 0.0f, 0.0f);
+    Vec3 transformed = m.transformPoint(point);
+
+    // Expected: scale (2,0,0), rotate to (0,2,0), translate to (1,4,3)
+    EXPECT_TRUE(almostEqual(transformed.x, 1.0f));
+    EXPECT_TRUE(almostEqual(transformed.y, 4.0f));
+    EXPECT_TRUE(almostEqual(transformed.z, 3.0f));
+}
+
+TEST(TransformTest, FromMatrixIdentity) {
+    Mat4 m = Mat4::identity();
+    Transform t = Transform::fromMatrix(m);
+
+    EXPECT_TRUE(almostEqual(t, Transform::identity()));
+}
+
+TEST(TransformTest, FromMatrixTranslation) {
+    Mat4 m = Mat4::translation(Vec3(1.0f, 2.0f, 3.0f));
+    Transform t = Transform::fromMatrix(m);
+
+    EXPECT_TRUE(almostEqual(t.position, Vec3(1.0f, 2.0f, 3.0f)));
+    EXPECT_TRUE(almostEqual(t.rotation, Quat::identity()));
+    EXPECT_TRUE(almostEqual(t.scale, Vec3(1.0f, 1.0f, 1.0f)));
+}
+
+TEST(TransformTest, FromMatrixRotation) {
+    Quat rot = Quat::fromAxisAngle(Vec3::unitY(), PI<float> / 4.0f);
+    Mat4 m = Mat4::rotation(rot);
+    Transform t = Transform::fromMatrix(m);
+
+    EXPECT_TRUE(almostEqual(t.position, Vec3::zero()));
+    EXPECT_TRUE(almostEqual(t.rotation, rot));
+    EXPECT_TRUE(almostEqual(t.scale, Vec3(1.0f, 1.0f, 1.0f)));
+}
+
+TEST(TransformTest, FromMatrixScale) {
+    Mat4 m = Mat4::scaling(Vec3(2.0f, 3.0f, 4.0f));
+    Transform t = Transform::fromMatrix(m);
+
+    EXPECT_TRUE(almostEqual(t.position, Vec3::zero()));
+    EXPECT_TRUE(almostEqual(t.rotation, Quat::identity()));
+    EXPECT_TRUE(almostEqual(t.scale, Vec3(2.0f, 3.0f, 4.0f)));
+}
+
+TEST(TransformTest, MatrixRoundTrip) {
+    // Create transform, convert to matrix, convert back
+    Vec3 pos(1.0f, 2.0f, 3.0f);
+    Quat rot = Quat::fromAxisAngle(Vec3(0.577f, 0.577f, 0.577f).normalized(), PI<float> / 3.0f);
+    Vec3 scl(2.0f, 3.0f, 4.0f);
+
+    Transform original(pos, rot, scl);
+    Mat4 m = original.toMatrix();
+    Transform roundTrip = Transform::fromMatrix(m);
+
+    EXPECT_TRUE(almostEqual(roundTrip.position, original.position));
+    EXPECT_TRUE(almostEqual(roundTrip.rotation, original.rotation));
+    EXPECT_TRUE(almostEqual(roundTrip.scale, original.scale));
+}
+
+// Inverse tests
+
+TEST(TransformTest, InverseIdentity) {
+    Transform t = Transform::identity();
+    Transform inv = t.inverse();
+
+    EXPECT_TRUE(almostEqual(inv, Transform::identity()));
+}
+
+TEST(TransformTest, InverseTranslation) {
+    Transform t(Vec3(1.0f, 2.0f, 3.0f));
+    Transform inv = t.inverse();
+
+    EXPECT_TRUE(almostEqual(inv.position, Vec3(-1.0f, -2.0f, -3.0f)));
+    EXPECT_TRUE(almostEqual(inv.rotation, Quat::identity()));
+    EXPECT_TRUE(almostEqual(inv.scale, Vec3(1.0f, 1.0f, 1.0f)));
+}
+
+TEST(TransformTest, InverseRotation) {
+    Quat rot = Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 2.0f);
+    Transform t(Vec3::zero(), rot);
+    Transform inv = t.inverse();
+
+    Quat expectedRot = rot.conjugate();
+    EXPECT_TRUE(almostEqual(inv.rotation, expectedRot));
+}
+
+TEST(TransformTest, InverseScale) {
+    Transform t(Vec3::zero(), Quat::identity(), Vec3(2.0f, 4.0f, 8.0f));
+    Transform inv = t.inverse();
+
+    EXPECT_TRUE(almostEqual(inv.scale, Vec3(0.5f, 0.25f, 0.125f)));
+}
+
+TEST(TransformTest, InverseComposition) {
+    Vec3 pos(1.0f, 2.0f, 3.0f);
+    Quat rot = Quat::fromAxisAngle(Vec3::unitY(), PI<float> / 4.0f);
+    Vec3 scl(2.0f, 2.0f, 2.0f);
+
+    Transform t(pos, rot, scl);
+    Transform inv = t.inverse();
+    Transform composed = t * inv;
+
+    // t * t^-1 should equal identity
+    EXPECT_TRUE(almostEqual(composed.position, Vec3::zero(), 1e-4f));
+    EXPECT_TRUE(almostEqual(composed.rotation, Quat::identity(), 1e-4f));
+    EXPECT_TRUE(almostEqual(composed.scale, Vec3(1.0f, 1.0f, 1.0f), 1e-4f));
+}
+
+// Point transformation tests
+
+TEST(TransformTest, TransformPointIdentity) {
+    Transform t = Transform::identity();
+    Vec3 point(1.0f, 2.0f, 3.0f);
+    Vec3 transformed = t.transformPoint(point);
+
+    EXPECT_TRUE(almostEqual(transformed, point));
+}
+
+TEST(TransformTest, TransformPointTranslation) {
+    Transform t(Vec3(1.0f, 2.0f, 3.0f));
+    Vec3 point(1.0f, 1.0f, 1.0f);
+    Vec3 transformed = t.transformPoint(point);
+
+    EXPECT_TRUE(almostEqual(transformed, Vec3(2.0f, 3.0f, 4.0f)));
+}
+
+TEST(TransformTest, TransformPointRotation) {
+    Quat rot = Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 2.0f);
+    Transform t(Vec3::zero(), rot);
+    Vec3 point(1.0f, 0.0f, 0.0f);
+    Vec3 transformed = t.transformPoint(point);
+
+    EXPECT_TRUE(almostEqual(transformed, Vec3(0.0f, 1.0f, 0.0f)));
+}
+
+TEST(TransformTest, TransformPointScale) {
+    Transform t(Vec3::zero(), Quat::identity(), Vec3(2.0f, 3.0f, 4.0f));
+    Vec3 point(1.0f, 1.0f, 1.0f);
+    Vec3 transformed = t.transformPoint(point);
+
+    EXPECT_TRUE(almostEqual(transformed, Vec3(2.0f, 3.0f, 4.0f)));
+}
+
+// Direction transformation tests
+
+TEST(TransformTest, TransformDirectionNoTranslation) {
+    Transform t(Vec3(100.0f, 200.0f, 300.0f));  // Translation should be ignored
+    Vec3 dir(1.0f, 0.0f, 0.0f);
+    Vec3 transformed = t.transformDirection(dir);
+
+    EXPECT_TRUE(almostEqual(transformed, dir));  // Should be unchanged
+}
+
+TEST(TransformTest, TransformDirectionRotation) {
+    Quat rot = Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 2.0f);
+    Transform t(Vec3::zero(), rot);
+    Vec3 dir(1.0f, 0.0f, 0.0f);
+    Vec3 transformed = t.transformDirection(dir);
+
+    EXPECT_TRUE(almostEqual(transformed, Vec3(0.0f, 1.0f, 0.0f)));
+}
+
+TEST(TransformTest, TransformDirectionScale) {
+    Transform t(Vec3::zero(), Quat::identity(), Vec3(2.0f, 3.0f, 4.0f));
+    Vec3 dir(1.0f, 1.0f, 1.0f);
+    Vec3 transformed = t.transformDirection(dir);
+
+    EXPECT_TRUE(almostEqual(transformed, Vec3(2.0f, 3.0f, 4.0f)));
+}
+
+// Normal transformation tests
+
+TEST(TransformTest, TransformNormalIdentity) {
+    Transform t = Transform::identity();
+    Vec3 normal(0.0f, 1.0f, 0.0f);
+    Vec3 transformed = t.transformNormal(normal);
+
+    EXPECT_TRUE(almostEqual(transformed, normal));
+}
+
+TEST(TransformTest, TransformNormalRotation) {
+    Quat rot = Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 2.0f);
+    Transform t(Vec3::zero(), rot);
+    Vec3 normal(1.0f, 0.0f, 0.0f);
+    Vec3 transformed = t.transformNormal(normal);
+
+    EXPECT_TRUE(almostEqual(transformed, Vec3(0.0f, 1.0f, 0.0f)));
+}
+
+TEST(TransformTest, TransformNormalNonUniformScale) {
+    // Non-uniform scale requires inverse transpose
+    Transform t(Vec3::zero(), Quat::identity(), Vec3(2.0f, 1.0f, 1.0f));
+    Vec3 normal(1.0f, 0.0f, 0.0f);
+    Vec3 transformed = t.transformNormal(normal);
+
+    // Normal should be normalized
+    EXPECT_TRUE(almostEqual(transformed.length(), 1.0f));
+}
+
+// Inverse transformation tests
+
+TEST(TransformTest, InverseTransformPointRoundTrip) {
+    Vec3 pos(1.0f, 2.0f, 3.0f);
+    Quat rot = Quat::fromAxisAngle(Vec3::unitY(), PI<float> / 3.0f);
+    Vec3 scl(2.0f, 2.0f, 2.0f);
+    Transform t(pos, rot, scl);
+
+    Vec3 point(5.0f, 6.0f, 7.0f);
+    Vec3 transformed = t.transformPoint(point);
+    Vec3 roundTrip = t.inverseTransformPoint(transformed);
+
+    EXPECT_TRUE(almostEqual(roundTrip, point, 1e-4f));
+}
+
+TEST(TransformTest, InverseTransformDirectionRoundTrip) {
+    Quat rot = Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 4.0f);
+    Vec3 scl(3.0f, 3.0f, 3.0f);
+    Transform t(Vec3::zero(), rot, scl);
+
+    Vec3 dir(1.0f, 0.0f, 0.0f);
+    Vec3 transformed = t.transformDirection(dir);
+    Vec3 roundTrip = t.inverseTransformDirection(transformed);
+
+    EXPECT_TRUE(almostEqual(roundTrip, dir));
+}
+
+// Composition tests
+
+TEST(TransformTest, CompositionIdentity) {
+    Transform t(Vec3(1.0f, 2.0f, 3.0f), Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 4.0f),
+                Vec3(2.0f, 2.0f, 2.0f));
+    Transform identity = Transform::identity();
+
+    Transform result = identity * t;
+    EXPECT_TRUE(almostEqual(result, t));
+}
+
+TEST(TransformTest, CompositionTranslation) {
+    Transform parent(Vec3(1.0f, 0.0f, 0.0f));
+    Transform child(Vec3(0.0f, 1.0f, 0.0f));
+
+    Transform combined = parent * child;
+    EXPECT_TRUE(almostEqual(combined.position, Vec3(1.0f, 1.0f, 0.0f)));
+}
+
+TEST(TransformTest, CompositionRotation) {
+    Quat rot1 = Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 4.0f);
+    Quat rot2 = Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 4.0f);
+    Transform parent(Vec3::zero(), rot1);
+    Transform child(Vec3::zero(), rot2);
+
+    Transform combined = parent * child;
+    Quat expectedRot = Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 2.0f);
+
+    EXPECT_TRUE(almostEqual(combined.rotation, expectedRot));
+}
+
+TEST(TransformTest, CompositionScale) {
+    Transform parent(Vec3::zero(), Quat::identity(), Vec3(2.0f, 2.0f, 2.0f));
+    Transform child(Vec3::zero(), Quat::identity(), Vec3(3.0f, 3.0f, 3.0f));
+
+    Transform combined = parent * child;
+    EXPECT_TRUE(almostEqual(combined.scale, Vec3(6.0f, 6.0f, 6.0f)));
+}
+
+TEST(TransformTest, CompositionHierarchy) {
+    // Test parent-child hierarchy
+    Transform parent(Vec3(10.0f, 0.0f, 0.0f), Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 2.0f),
+                     Vec3(2.0f, 2.0f, 2.0f));
+    Transform child(Vec3(5.0f, 0.0f, 0.0f));
+
+    Transform world = parent * child;
+
+    // Child at (5,0,0) in parent space:
+    // - Scaled by (2,2,2) -> (10,0,0)
+    // - Rotated 90deg around Z -> (0,10,0)
+    // - Translated by (10,0,0) -> (10,10,0)
+    EXPECT_TRUE(almostEqual(world.position, Vec3(10.0f, 10.0f, 0.0f)));
+}
+
+TEST(TransformTest, CompositionPointTransform) {
+    Transform parent(Vec3(1.0f, 0.0f, 0.0f));
+    Transform child(Vec3(1.0f, 0.0f, 0.0f));
+    Transform combined = parent * child;
+
+    Vec3 point(1.0f, 0.0f, 0.0f);
+    Vec3 transformed1 = combined.transformPoint(point);
+    Vec3 transformed2 = parent.transformPoint(child.transformPoint(point));
+
+    EXPECT_TRUE(almostEqual(transformed1, transformed2));
+}
+
+// Comparison operator tests
+
+TEST(TransformTest, EqualityOperator) {
+    Transform t1(Vec3(1.0f, 2.0f, 3.0f), Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 4.0f),
+                 Vec3(2.0f, 2.0f, 2.0f));
+    Transform t2(Vec3(1.0f, 2.0f, 3.0f), Quat::fromAxisAngle(Vec3::unitZ(), PI<float> / 4.0f),
+                 Vec3(2.0f, 2.0f, 2.0f));
+
+    EXPECT_TRUE(t1 == t2);
+}
+
+TEST(TransformTest, InequalityOperator) {
+    Transform t1(Vec3(1.0f, 2.0f, 3.0f));
+    Transform t2(Vec3(1.0f, 2.0f, 4.0f));
+
+    EXPECT_TRUE(t1 != t2);
+}
+
+// Numerical precision tests
+
+TEST(TransformTest, NumericalPrecision) {
+    // Test that operations maintain precision within epsilon
+    Vec3 pos(1.234567f, 2.345678f, 3.456789f);
+    Quat rot = Quat::fromAxisAngle(Vec3::unitY(), 1.23456f);
+    Vec3 scl(1.5f, 2.5f, 3.5f);
+
+    Transform t(pos, rot, scl);
+    Mat4 m = t.toMatrix();
+    Transform roundTrip = Transform::fromMatrix(m);
+
+    // Precision should be within 1e-5
+    EXPECT_TRUE(almostEqual(roundTrip.position, pos, 1e-5f));
+    EXPECT_TRUE(almostEqual(roundTrip.rotation, rot, 1e-5f));
+    EXPECT_TRUE(almostEqual(roundTrip.scale, scl, 1e-5f));
+}


### PR DESCRIPTION
## Summary

This PR implements the Transform type for unified handling of position, rotation, and scale in 3D transformations. Transform provides a clean abstraction for rigid body poses, hierarchical scene graphs, and coordinate space conversions throughout the physics engine.

## Changes Made

### Core Implementation

- **Transform struct** (`include/axiom/math/transform.hpp`)
  - Position (Vec3), rotation (Quat), and scale (Vec3) components
  - Constexpr constructors for compile-time initialization
  - Comprehensive Doxygen documentation

### Transformation Operations

- **Matrix conversion**
  - `toMatrix()`: TRS composition (translate * rotate * scale)
  - `fromMatrix()`: Matrix decomposition with scale extraction
  - Maintains numerical precision within 1e-5 tolerance

- **Transform composition**
  - `operator*`: Parent-child hierarchy composition
  - Proper TRS order for combined transformations

- **Point/Vector transformation**
  - `transformPoint()`: Full TRS transformation
  - `transformDirection()`: Rotation + scale (no translation)
  - `transformNormal()`: Inverse transpose for correct normal handling
  - Inverse variants for world-to-local conversion

- **Inverse transform**
  - Efficient computation of inverse transformation
  - Verified with composition tests (T * T⁻¹ ≈ I)

### Testing

- **41 comprehensive unit tests** (`tests/math/transform_test.cpp`)
  - Constructor and factory method tests
  - Matrix conversion round-trip validation
  - Inverse transform verification
  - Point, direction, and normal transformation tests
  - Hierarchical composition tests
  - Numerical precision validation
  - All tests pass (179/179 total)

### Documentation & Examples

- **Example program** (`examples/transform_example.cpp`)
  - Demonstrates basic transform usage
  - Parent-child hierarchy examples
  - Matrix conversion examples
  - Inverse transform usage

## Usage

```cpp
// Create transforms
Transform parent(Vec3(10.0f, 0.0f, 0.0f), 
                 Quat::fromAxisAngle(Vec3::unitZ(), PI / 4.0f));
Transform child(Vec3(5.0f, 0.0f, 0.0f));

// Compose transforms (parent-child hierarchy)
Transform world = parent * child;

// Transform points
Vec3 localPoint(1.0f, 0.0f, 0.0f);
Vec3 worldPoint = world.transformPoint(localPoint);

// Matrix conversion
Mat4 matrix = world.toMatrix();
Transform fromMat = Transform::fromMatrix(matrix);

// Inverse transform
Transform inverse = world.inverse();
Vec3 backToLocal = inverse.transformPoint(worldPoint);
```

## Testing

- [x] Code follows project conventions (clang-format applied)
- [x] All 179 tests pass (41 new Transform tests)
- [x] Numerical precision verified (< 1e-5 error)
- [x] No compiler warnings
- [x] Documentation complete with Doxygen comments

## Checklist

- [x] clang-format applied
- [x] CMake builds successfully (Debug)
- [x] Unit tests added with comprehensive coverage
- [x] Example program created
- [x] All acceptance criteria met

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Transform utility for managing position, rotation (quaternion), and per-axis scale.
  * Supports point and vector transformations, matrix conversion, transform composition, and inverse operations.

* **Tests**
  * Added comprehensive test suite for Transform functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->